### PR TITLE
changed A2S_INFO to a challenged request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ SteamQuery\.egg-info/
 build/lib/steam/__init__\.py
 
 build/lib/steam/query\.py
+
+venv

--- a/steam/query.py
+++ b/steam/query.py
@@ -59,8 +59,9 @@ class SteamQuery:
 
     @_query_function
     def _query_server_info(self, *, udpsock) -> dict:
-        payload = A2S_INFO_HEADER + A2S_INFO_PAYLOAD
-        data = self._make_request(udpsock, payload)
+        data = self._make_challenged_request(
+            udpsock, A2S_INFO_HEADER + A2S_INFO_PAYLOAD
+        )
         server_info = self._unpack_server_data(data)
         if server_info is not None:
             return server_info


### PR DESCRIPTION
As noted in the [Valve Developer Community Wiki entry](https://developer.valvesoftware.com/wiki/Server_queries), `A2S_INFO` can now be a challenged request:
> Servers may respond with the data immediately. However, since this reply is larger than the request, it makes the server vulnerable to a reflection amplification attack. Instead, the server may reply with a challenge to the client using S2C_CHALLENGE ('A' or 0x41). In that case, the client should repeat the request by appending the challenge number. This change was introduced in December 2020 to address the reflection attack vulnerability, and all clients are encouraged to support the new protocol. See [this post](https://steamcommunity.com/discussions/forum/14/2974028351344359625/) for more info. 

Among probably others, Squad servers have already implemented this change.

This PR simply uses the existing `_make_challenged_request` already used for `A2S_PLAYER` and `A2S_RULES`.

This *should* be backwards-compatible, as `_make_challenged_request` merely adds placeholder challenge data to the first request which older servers *should* simply ignore. On the receiving end, `_make_challenged_request` will correctly handle an immediate non-challenge response.